### PR TITLE
Make it possible to have gaps between two records by not requireing t…

### DIFF
--- a/bitpack/stream.py
+++ b/bitpack/stream.py
@@ -89,18 +89,16 @@ class BitStream(object):
         """
         bitstream = bitarray()
         bitstream.frombytes(self._data)
+        start_pattern = bitarray()
+        start_pattern.frombytes(self.start_marker)
         end_pattern = bitarray()
         end_pattern.frombytes(self.end_marker)
-        pattern_width = end_pattern.length()
-        start = pattern_width
+        pattern_width = start_pattern.length()
         deserialized = []
-        for end in bitstream.itersearch(end_pattern):
-            found_start = bitstream[start - pattern_width:start].tobytes()
-            if found_start != self.start_marker:
-                raise ValueError('Start marker does not match.')
-            data = self._from_datagram(bitstream[start:end])
+        for (start, end) in zip(bitstream.itersearch(start_pattern),
+                                bitstream.itersearch(end_pattern)):
+            data = self._from_datagram(bitstream[start + pattern_width:end])
             deserialized.append(data)
-            start = end + pattern_width * 2
         return deserialized
 
     @classmethod

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -111,8 +111,28 @@ def test_deserialize(bit_stream):
 def test_deserialize_start_marker_mismatch(bit_stream):
     data = 'HBU\x90\x08\x00\x00\x1e\x1e\x56\x91\x2a\xf3\x53\xd0\x92\x00'
     inst = bit_stream(data)
-    with pytest.raises(ValueError):
-        inst.deserialize()
+    assert inst.deserialize() == []
+
+
+def test_deserialize_end_marker_mismatch(bit_stream):
+    data = 'HBO\x90\x08\x00\x00\x1e\x1e\x56\x91\x2a\xf3\x53\xd0\x93\x00'
+    inst = bit_stream(data)
+    assert inst.deserialize() == []
+
+
+def test_concatenate_serialized_forms(bit_stream):
+    single = 'HBO\x90\x08\x00\x00\x1e\x1e\x56\x91\x2a\xf3\x53\xd0\x92\x00'
+    concatenated = single + single
+    expected = [{'int_fld': 2,
+                 'flt_fld': 2.5,
+                 'str_fld': 'xyZD',
+                 'hex_fld': 'abcd'},
+                {'int_fld': 2,
+                 'flt_fld': 2.5,
+                 'str_fld': 'xyZD',
+                 'hex_fld': 'abcd'}]
+    inst = bit_stream(concatenated)
+    assert inst.deserialize() == expected
 
 
 @mock.patch.object(mod.BitStream, 'deserialize')


### PR DESCRIPTION
Make it possible to have gaps between two records by not requireing the start marker to be on a fixed relative offset from the end marker. Proved with a test.
